### PR TITLE
Unicode aliases (closes #111)

### DIFF
--- a/src-tauri/src/command/mod.rs
+++ b/src-tauri/src/command/mod.rs
@@ -166,6 +166,7 @@ pub fn default_dispatch_table() -> CommandDispatchTable {
   map.insert("contourplot".to_string(), Box::new(graphics::ContourPlotCommand::new()));
   map.insert("xy".to_string(), Box::new(BinaryFunctionCommand::named("xy")));
   map.insert("toggle_graphics".to_string(), Box::new(modes::toggle_graphics_command()));
+  map.insert("toggle_unicode".to_string(), Box::new(modes::toggle_unicode_command()));
   map.insert("toggle_infinity".to_string(), Box::new(modes::toggle_infinity_command()));
 
   // Unit conversion

--- a/src-tauri/src/command/modes.rs
+++ b/src-tauri/src/command/modes.rs
@@ -68,6 +68,23 @@ pub fn toggle_graphics_command() -> impl Command + Send + Sync {
   })
 }
 
+pub fn toggle_unicode_command() -> impl Command + Send + Sync {
+  fn toggle_flag_change() -> ToggleFlagChange<fn(&mut UndoableState) -> &mut bool> {
+    ToggleFlagChange::new("prefers_unicode_output", |state| {
+      &mut state.display_settings_mut().language_settings.prefers_unicode_output
+    })
+  }
+
+  GeneralCommand::new(|state, args, _| {
+    NullaryArgumentSchema::new().validate(args)?;
+    state.undo_stack_mut().push_cut();
+    state.undo_stack_mut().push_change(toggle_flag_change());
+    let settings = &mut state.display_settings_mut().language_settings;
+    settings.prefers_unicode_output = !settings.prefers_unicode_output;
+    Ok(CommandOutput::success())
+  })
+}
+
 pub fn toggle_infinity_command() -> impl Command + Send + Sync {
   GeneralCommand::new(|state, args, _| {
     NullaryArgumentSchema::new().validate(args)?;

--- a/src-tauri/src/expr/simplifier/unicode.rs
+++ b/src-tauri/src/expr/simplifier/unicode.rs
@@ -1,0 +1,109 @@
+
+use super::base::{Simplifier, SimplifierContext};
+use crate::mode::display::unicode::{UnicodeAliasTable, common_unicode_aliases};
+use crate::expr::Expr;
+use crate::expr::var::Var;
+use crate::expr::atom::Atom;
+
+/// A simplifier which recognizes Unicode names and simplifies them
+/// down to their canonical ASCII equivalents.
+#[derive(Debug)]
+pub struct UnicodeSimplifier {
+  table: UnicodeAliasTable,
+}
+
+impl UnicodeSimplifier {
+  pub fn new(table: UnicodeAliasTable) -> Self {
+    Self { table }
+  }
+
+  pub fn from_common_aliases() -> Self {
+    Self::new(common_unicode_aliases())
+  }
+
+  fn lookup_ascii_name<'a>(&'a self, unicode_name: &'a str) -> &'a str {
+    self.table.get_ascii(unicode_name).unwrap_or(unicode_name)
+  }
+}
+
+impl Simplifier for UnicodeSimplifier {
+  fn simplify_expr_part(&self, expr: Expr, _: &mut SimplifierContext) -> Expr {
+    match expr {
+      Expr::Atom(Atom::Var(var)) => {
+        let canonical_name = self.lookup_ascii_name(var.as_str());
+        let Some(new_var) = Var::new(canonical_name) else {
+          eprintln!("UnicodeSimplifier: Got invalid variable name {canonical_name:?}");
+          return Expr::Atom(Atom::Var(var));
+        };
+        Expr::Atom(Atom::Var(new_var))
+      }
+      Expr::Atom(Atom::String(_) | Atom::Number(_)) => expr,
+      Expr::Call(name, args) => {
+        Expr::call(self.lookup_ascii_name(name.as_str()), args)
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::expr::simplifier::test_utils::run_simplifier;
+  use crate::mode::display::unicode::UnicodeAlias;
+
+  fn sample_simplifier() -> UnicodeSimplifier {
+    let table = UnicodeAliasTable::new(vec![
+      UnicodeAlias::simple("otimes", "⊗"),
+      UnicodeAlias::simple("infty", "∞"),
+      UnicodeAlias::new("less_or_equal", "≤", vec![String::from("⪯")]),
+    ]).unwrap();
+    UnicodeSimplifier::new(table)
+  }
+
+  #[test]
+  fn test_unicode_simplifier() {
+    let simplifier = sample_simplifier();
+
+    let in_expr = Expr::call("≤", vec![
+      Expr::from(10),
+      Expr::call("⊗", vec![
+        Expr::from(20),
+        Expr::from(30),
+        Expr::var("∞").unwrap(),
+        Expr::var("infty").unwrap(),
+      ]),
+    ]);
+    let (out_expr, errors) = run_simplifier(&simplifier, in_expr);
+    assert!(errors.is_empty());
+    assert_eq!(out_expr, Expr::call("less_or_equal", vec![
+      Expr::from(10),
+      Expr::call("otimes", vec![
+        Expr::from(20),
+        Expr::from(30),
+        Expr::var("infty").unwrap(),
+        Expr::var("infty").unwrap(),
+      ]),
+    ]));
+
+    let in_expr = Expr::call("⪯", vec![
+      Expr::from(10),
+      Expr::call("otimes", vec![
+        Expr::from(20),
+        Expr::from(30),
+        Expr::var("infty").unwrap(),
+        Expr::var("∞").unwrap(),
+      ]),
+    ]);
+    let (out_expr, errors) = run_simplifier(&simplifier, in_expr);
+    assert!(errors.is_empty());
+    assert_eq!(out_expr, Expr::call("less_or_equal", vec![
+      Expr::from(10),
+      Expr::call("otimes", vec![
+        Expr::from(20),
+        Expr::from(30),
+        Expr::var("infty").unwrap(),
+        Expr::var("infty").unwrap(),
+      ]),
+    ]));
+  }
+}

--- a/src-tauri/src/expr/var/mod.rs
+++ b/src-tauri/src/expr/var/mod.rs
@@ -31,11 +31,11 @@ pub struct TryFromStringError {
 }
 
 pub static VALID_NAME_RE: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"^[a-zA-Z$][a-zA-Z$0-9']*$").unwrap()
+  Regex::new(r"^(?:[a-zA-Z$][a-zA-Z$0-9']*|∞|⧝)$").unwrap()
 });
 
 pub static VALID_NAME_PREFIX_RE: Lazy<Regex> = Lazy::new(|| {
-  Regex::new(r"^[a-zA-Z$][a-zA-Z$0-9']*").unwrap()
+  Regex::new(r"^(?:[a-zA-Z$][a-zA-Z$0-9']*|∞|⧝)").unwrap()
 });
 
 impl Var {
@@ -122,6 +122,7 @@ mod test {
     Var::new("$a$").unwrap();
     Var::new("$A$").unwrap();
     Var::new("A$").unwrap();
+    Var::new("∞").unwrap();
   }
 
   #[test]
@@ -143,6 +144,9 @@ mod test {
     assert_eq!(Var::new("'''''''"), None);
     assert_eq!(Var::new("$^"), None);
     assert_eq!(Var::new("$["), None);
+    assert_eq!(Var::new("$∞"), None);
+    assert_eq!(Var::new("∞x"), None);
+    assert_eq!(Var::new("∞∞"), None);
   }
 
   #[test]

--- a/src-tauri/src/mode/display/language/basic.rs
+++ b/src-tauri/src/mode/display/language/basic.rs
@@ -352,7 +352,6 @@ mod tests {
   fn sample_unicode_table() -> UnicodeAliasTable {
     UnicodeAliasTable::new(vec![
       UnicodeAlias::simple("A", "𝔸"),
-      UnicodeAlias::simple("otimes", "⊗"),
     ]).unwrap()
   }
 

--- a/src-tauri/src/mode/display/language/basic.rs
+++ b/src-tauri/src/mode/display/language/basic.rs
@@ -1,5 +1,6 @@
 
 use super::{LanguageMode, LanguageModeEngine, output_sep_by};
+use crate::mode::display::unicode::{UnicodeAliasTable, common_unicode_aliases};
 use crate::parsing::operator::{Operator, Precedence, OperatorTable};
 use crate::parsing::operator::fixity::FixityType;
 use crate::expr::Expr;
@@ -15,6 +16,7 @@ use num::Zero;
 #[derive(Clone, Debug, Default)]
 pub struct BasicLanguageMode {
   known_operators: OperatorTable,
+  unicode_table: UnicodeAliasTable,
   // Default is false. If true, the output should be readable by the
   // default parser. If false, some things may be pretty-printed (such
   // as incomplete objects).
@@ -26,18 +28,39 @@ impl BasicLanguageMode {
     Self::default()
   }
 
+  /// Replaces the [`UnicodeAliasTable`] associated with `self` and
+  /// returns a modified version of `self`.
+  pub fn with_unicode_table(mut self, table: UnicodeAliasTable) -> Self {
+    self.unicode_table = table;
+    self
+  }
+
   pub fn from_operators(known_operators: OperatorTable) -> Self {
     Self {
       known_operators,
+      unicode_table: UnicodeAliasTable::default(),
       uses_reversible_output: false,
     }
   }
 
   pub fn from_common_operators() -> Self {
     Self::from_operators(OperatorTable::common_operators())
+      .with_unicode_table(common_unicode_aliases())
+  }
+
+  fn translate_to_unicode<'a>(&'a self, engine: &LanguageModeEngine, ascii_name: &'a str) -> &'a str {
+    if !engine.language_settings().prefers_unicode_output || self.uses_reversible_output {
+      // Technically, we could output Unicode in reversible mode,
+      // since the parser supports it. But in the interests of showing
+      // the user a more "canonical" version of the value, we disable
+      // Unicode output unconditionally.
+      return ascii_name;
+    }
+    self.unicode_table.get_unicode(ascii_name).unwrap_or(ascii_name)
   }
 
   fn fn_call_to_html(&self, engine: &LanguageModeEngine, out: &mut String, f: &str, args: &[Expr]) {
+    let f = self.translate_to_unicode(engine, f);
     out.push_str(f);
     out.push('(');
     output_sep_by(out, args.iter(), ", ", |out, e| engine.write_to_html(out, e, Precedence::MIN));
@@ -65,7 +88,8 @@ impl BasicLanguageMode {
     // Special case: Infix multiplication can always be represented as
     // juxtaposition.
     if op.operator_name() != "*" {
-      out.push_str(op.operator_name());
+      let operator_name = self.translate_to_unicode(engine, op.operator_name());
+      out.push_str(operator_name);
       out.push(' ');
     }
     engine.write_to_html(out, right_arg, infix_props.right_precedence());
@@ -97,7 +121,8 @@ impl BasicLanguageMode {
         // Special case: Infix multiplication can always be represented as
         // juxtaposition.
         if op.operator_name() != "*" {
-          out.push_str(op.operator_name());
+          let operator_name = self.translate_to_unicode(engine, op.operator_name());
+          out.push_str(operator_name);
           out.push(' ');
         }
       }
@@ -130,7 +155,8 @@ impl BasicLanguageMode {
     if needs_parens {
       out.push('(');
     }
-    out.push_str(op.operator_name());
+    let operator_name = self.translate_to_unicode(engine, op.operator_name());
+    out.push_str(operator_name);
     out.push(' ');
     engine.write_to_html(out, &args[0], prefix_props.precedence());
     if needs_parens {
@@ -155,7 +181,8 @@ impl BasicLanguageMode {
     }
     engine.write_to_html(out, &args[0], postfix_props.precedence());
     out.push(' ');
-    out.push_str(op.operator_name());
+    let operator_name = self.translate_to_unicode(engine, op.operator_name());
+    out.push_str(operator_name);
     if needs_parens {
       out.push(')');
     }
@@ -254,7 +281,8 @@ impl LanguageMode for BasicLanguageMode {
         }
       }
       Expr::Atom(Atom::Var(v)) => {
-        out.push_str(&v.to_string());
+        let var = self.translate_to_unicode(engine, v.as_str());
+        out.push_str(var);
       }
       Expr::Atom(Atom::String(s)) => {
         write_escaped_str(out, s).unwrap(); // unwrap: impl Write for String doesn't fail.
@@ -306,10 +334,26 @@ impl LanguageMode for BasicLanguageMode {
 mod tests {
   use super::*;
   use crate::mode::display::language::LanguageSettings;
+  use crate::mode::display::unicode::{UnicodeAlias, UnicodeAliasTable};
 
-  fn to_html(mode: &BasicLanguageMode, expr: &Expr) -> String {
+  fn to_html<M>(mode: &M, expr: &Expr) -> String
+  where M: LanguageMode + ?Sized {
     let settings = LanguageSettings::default();
     mode.to_html(expr, &settings)
+  }
+
+  fn to_html_no_unicode<M>(mode: &M, expr: &Expr) -> String
+  where M: LanguageMode + ?Sized {
+    let mut settings = LanguageSettings::default();
+    settings.prefers_unicode_output = false;
+    mode.to_html(expr, &settings)
+  }
+
+  fn sample_unicode_table() -> UnicodeAliasTable {
+    UnicodeAliasTable::new(vec![
+      UnicodeAlias::simple("A", "𝔸"),
+      UnicodeAlias::simple("otimes", "⊗"),
+    ]).unwrap()
   }
 
   #[test]
@@ -346,6 +390,61 @@ mod tests {
     assert_eq!(to_html(&mode, &expr), "foo(9)");
     let expr = Expr::call("foo", vec![]);
     assert_eq!(to_html(&mode, &expr), "foo()");
+  }
+
+  #[test]
+  fn test_simple_function_call_with_unicode() {
+    let mode = BasicLanguageMode::default()
+      .with_unicode_table(sample_unicode_table());
+    let expr = Expr::call("foo", vec![Expr::from(9), Expr::from(8), Expr::from(7)]);
+    assert_eq!(to_html(&mode, &expr), "foo(9, 8, 7)");
+    let expr = Expr::call("foo", vec![Expr::from(9)]);
+    assert_eq!(to_html(&mode, &expr), "foo(9)");
+    let expr = Expr::call("foo", vec![]);
+    assert_eq!(to_html(&mode, &expr), "foo()");
+    let expr = Expr::call("A", vec![]);
+    assert_eq!(to_html(&mode, &expr), "𝔸()");
+    let expr = Expr::call("A", vec![Expr::from(10), Expr::from(20)]);
+    assert_eq!(to_html(&mode, &expr), "𝔸(10, 20)");
+    let expr = Expr::call("A", vec![Expr::var("A").unwrap(), Expr::var("a").unwrap()]);
+    assert_eq!(to_html(&mode, &expr), "𝔸(𝔸, a)");
+  }
+
+  #[test]
+  fn test_simple_function_call_with_unicode_in_reversible_mode() {
+    let mode = BasicLanguageMode::default()
+      .with_unicode_table(sample_unicode_table());
+    let mode = mode.to_reversible_language_mode();
+    let expr = Expr::call("foo", vec![Expr::from(9), Expr::from(8), Expr::from(7)]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "foo(9, 8, 7)");
+    let expr = Expr::call("foo", vec![Expr::from(9)]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "foo(9)");
+    let expr = Expr::call("foo", vec![]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "foo()");
+    let expr = Expr::call("A", vec![]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "A()");
+    let expr = Expr::call("A", vec![Expr::from(10), Expr::from(20)]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "A(10, 20)");
+    let expr = Expr::call("A", vec![Expr::var("A").unwrap(), Expr::var("a").unwrap()]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "A(A, a)");
+  }
+
+  #[test]
+  fn test_simple_function_call_with_unicode_with_unicode_preferences_off() {
+    let mode = BasicLanguageMode::default()
+      .with_unicode_table(sample_unicode_table());
+    let expr = Expr::call("foo", vec![Expr::from(9), Expr::from(8), Expr::from(7)]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "foo(9, 8, 7)");
+    let expr = Expr::call("foo", vec![Expr::from(9)]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "foo(9)");
+    let expr = Expr::call("foo", vec![]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "foo()");
+    let expr = Expr::call("A", vec![]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "A()");
+    let expr = Expr::call("A", vec![Expr::from(10), Expr::from(20)]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "A(10, 20)");
+    let expr = Expr::call("A", vec![Expr::var("A").unwrap(), Expr::var("a").unwrap()]);
+    assert_eq!(to_html_no_unicode(&mode, &expr), "A(A, a)");
   }
 
   #[test]
@@ -508,6 +607,23 @@ mod tests {
       vec![Expr::string("[")],
     );
     assert_eq!(to_html(&mode, &expr), "[ ...");
+  }
+
+  #[test]
+  fn test_unicode_operator() {
+    let mode = BasicLanguageMode::from_common_operators();
+    let expr = Expr::call("<=", vec![Expr::from(100), Expr::from(200)]);
+    assert_eq!(to_html(&mode, &expr), "100 ≤ 200");
+    assert_eq!(to_html_no_unicode(&mode, &expr), "100 <= 200");
+  }
+
+  #[test]
+  fn test_unicode_operator_in_reversible_mode() {
+    let mode = BasicLanguageMode::from_common_operators();
+    let mode = mode.to_reversible_language_mode();
+    let expr = Expr::call("<=", vec![Expr::from(100), Expr::from(200)]);
+    assert_eq!(to_html(mode.as_ref(), &expr), "100 <= 200");
+    assert_eq!(to_html_no_unicode(mode.as_ref(), &expr), "100 <= 200");
   }
 
   #[test]

--- a/src-tauri/src/mode/display/language/mod.rs
+++ b/src-tauri/src/mode/display/language/mod.rs
@@ -62,7 +62,14 @@ pub struct LanguageModeEngine<'a, 'b> {
 
 #[derive(Debug, Clone)]
 pub struct LanguageSettings {
+  /// The preferred radix for outputting real numbers.
   pub preferred_radix: Radix,
+  /// If true, the user prefers certain operator, function, and
+  /// variable names to be replaced with Unicode equivalents in
+  /// output. This does NOT affect input, which always accepts either
+  /// an ASCII name or its Unicode equivalent(s), regardless of this
+  /// flag.
+  pub prefers_unicode_output: bool,
 }
 
 impl<'a, 'b> LanguageModeEngine<'a, 'b> {
@@ -77,7 +84,10 @@ impl<'a, 'b> LanguageModeEngine<'a, 'b> {
 
 impl Default for LanguageSettings {
   fn default() -> Self {
-    LanguageSettings { preferred_radix: Radix::DECIMAL }
+    LanguageSettings {
+      preferred_radix: Radix::DECIMAL,
+      prefers_unicode_output: true,
+    }
   }
 }
 

--- a/src-tauri/src/mode/display/mod.rs
+++ b/src-tauri/src/mode/display/mod.rs
@@ -1,5 +1,6 @@
 
 pub mod language;
+pub mod unicode;
 
 use crate::expr::Expr;
 use language::{LanguageMode, LanguageSettings};

--- a/src-tauri/src/mode/display/unicode/alias.rs
+++ b/src-tauri/src/mode/display/unicode/alias.rs
@@ -1,0 +1,42 @@
+
+use std::iter;
+
+/// All variables and operators in the expression language are, by
+/// default, ASCII strings. However, for many names, it's convenient
+/// to use Unicode equivalents. A `UnicodeAlias` defines a canonical
+/// ASCII name for a variable, function, or operator, as well as one
+/// or more Unicode names which should be considered equivalent.
+///
+/// One of these Unicode names is considered the most correct name and
+/// will be used when pretty-printing the original name, while the
+/// others (if any) are not used in printing but will be accepted as
+/// equivalent in input.
+#[derive(Debug, Clone)]
+pub struct UnicodeAlias {
+  pub(super) ascii_name: String,
+  pub(super) best_unicode_name: String,
+  pub(super) other_unicode_names: Vec<String>,
+}
+
+impl UnicodeAlias {
+  pub fn new(
+    ascii_name: impl Into<String>,
+    best_unicode_name: impl Into<String>,
+    other_unicode_names: Vec<String>,
+  ) -> Self {
+    Self {
+      ascii_name: ascii_name.into(),
+      best_unicode_name: best_unicode_name.into(),
+      other_unicode_names,
+    }
+  }
+
+  pub fn simple(ascii_name: impl Into<String>, unicode_name: impl Into<String>) -> Self {
+    Self::new(ascii_name, unicode_name, Vec::new())
+  }
+
+  pub(super) fn unicode_names(&self) -> impl Iterator<Item = &str> {
+    iter::once(&self.best_unicode_name).chain(&self.other_unicode_names)
+      .map(String::as_str)
+  }
+}

--- a/src-tauri/src/mode/display/unicode/mod.rs
+++ b/src-tauri/src/mode/display/unicode/mod.rs
@@ -1,0 +1,28 @@
+
+mod alias;
+mod table;
+
+pub use alias::UnicodeAlias;
+pub use table::{UnicodeAliasTable, UnicodeTableError};
+
+pub fn common_unicode_aliases() -> UnicodeAliasTable {
+  UnicodeAliasTable::new(vec![
+    UnicodeAlias::simple("<=", "≤"),
+    UnicodeAlias::simple("=>", "≥"),
+    UnicodeAlias::simple("!=", "≠"),
+    UnicodeAlias::simple("inf", "∞"),
+    UnicodeAlias::simple("uinf", "⧝"),
+  ]).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_common_unicode_aliases_contains_no_duplicates() {
+    // Simply instantiate the table, to ensure that the constructor
+    // doesn't return an `Err`.
+    common_unicode_aliases();
+  }
+}

--- a/src-tauri/src/mode/display/unicode/table.rs
+++ b/src-tauri/src/mode/display/unicode/table.rs
@@ -1,0 +1,68 @@
+
+use super::alias::UnicodeAlias;
+
+use thiserror::Error;
+
+use std::collections::HashMap;
+
+/// A table mapping canonical ASCII names to Unicode aliases and vice
+/// versa. Every ASCII name that appears in the table must map to a
+/// single, canonical Unicode equivalent. But multiple Unicode names
+/// can map to the same ASCII name.
+///
+/// This mapping is its own one-sided inverse. That is, if you start
+/// with an ASCII name present in the table, get the Unicode name, and
+/// then go back, you will get the original ASCII name. But the same
+/// is NOT true if you start with a Unicode name.
+#[derive(Debug, Clone, Default)]
+pub struct UnicodeAliasTable {
+  ascii_to_unicode: HashMap<String, String>,
+  unicode_to_ascii: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum UnicodeTableError {
+  #[error("ASCII name already exists: {0}")]
+  AsciiNameAlreadyExists(String),
+  #[error("Unicode name already exists: {0}")]
+  UnicodeNameAlreadyExists(String),
+}
+
+impl UnicodeAliasTable {
+  pub fn new(aliases: impl IntoIterator<Item = UnicodeAlias>) -> Result<Self, UnicodeTableError> {
+    let mut table = Self::default();
+    for alias in aliases {
+      table.insert(alias)?;
+    }
+    Ok(table)
+  }
+
+  pub fn get_unicode(&self, ascii_name: &str) -> Option<&str> {
+    self.ascii_to_unicode.get(ascii_name).map(|s| s.as_str())
+  }
+
+  pub fn get_ascii(&self, unicode_name: &str) -> Option<&str> {
+    self.unicode_to_ascii.get(unicode_name).map(|s| s.as_str())
+  }
+
+  /// Attempts to insert a new alias into the table. If any of the
+  /// names in the new alias struct are already present in the table,
+  /// this method returns an error without modifying the table.
+  pub fn insert(&mut self, alias: UnicodeAlias) -> Result<(), UnicodeTableError> {
+    if self.ascii_to_unicode.contains_key(&alias.ascii_name) {
+      return Err(UnicodeTableError::AsciiNameAlreadyExists(alias.ascii_name));
+    }
+    for name in alias.unicode_names() {
+      if self.unicode_to_ascii.contains_key(name) {
+        return Err(UnicodeTableError::UnicodeNameAlreadyExists(name.to_owned()));
+      }
+    }
+    self.ascii_to_unicode.insert(alias.ascii_name.clone(), alias.best_unicode_name.clone());
+    self.unicode_to_ascii.insert(alias.best_unicode_name, alias.ascii_name.clone());
+    for name in alias.other_unicode_names {
+      self.unicode_to_ascii.insert(name, alias.ascii_name.clone());
+    }
+    Ok(())
+  }
+}

--- a/src-tauri/src/parsing/operator/table.rs
+++ b/src-tauri/src/parsing/operator/table.rs
@@ -88,6 +88,11 @@ impl OperatorTable {
       Operator::new(">=", Fixity::new().with_infix(">=", Associativity::NONE, Precedence::new(160))),
       Operator::new("&&", Fixity::new().with_infix("&&", Associativity::FULL, Precedence::new(110))),
       Operator::new("||", Fixity::new().with_infix("||", Associativity::FULL, Precedence::new(100))),
+
+      // Also admit Unicode equivalents to several operators.
+      Operator::new("≠", Fixity::new().with_infix("≠", Associativity::NONE, Precedence::new(160))),
+      Operator::new("≤", Fixity::new().with_infix("≤", Associativity::NONE, Precedence::new(160))),
+      Operator::new("≥", Fixity::new().with_infix("≥", Associativity::NONE, Precedence::new(160))),
     ].into_iter().collect()
   }
 

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -133,9 +133,9 @@ impl ApplicationState {
       modeline.push_str("-  ");
     }
     if self.display_settings().language_settings.prefers_unicode_output {
-      modeline.push_str("U");
+      modeline.push('U');
     } else {
-      modeline.push_str("-");
+      modeline.push('-');
     }
     if self.display_settings().is_graphics_enabled {
       modeline.push_str("Gr");

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -218,9 +218,10 @@ fn modeline_str_for_radix(radix: Radix) -> String {
     8 => String::from("Oct"),
     10 => String::from("Dec"),
     16 => String::from("Hex"),
-    n => format!("R={}", n),
+    n if n < 10 => format!("R={}", n),
+    n => format!("R{}", n),
   };
-  format!("{:5}", s)
+  format!("{:3}", s)
 }
 
 impl UndoableState {

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -121,6 +121,9 @@ impl ApplicationState {
     Ok(())
   }
 
+  /// The modeline, which appears in teletype font at the bottom of
+  /// the screen and indicates the current values of various
+  /// user-specified flags.
   pub fn modeline(&self) -> String {
     let mut modeline = String::new();
     modeline.push_str(&modeline_str_for_radix(self.display_settings().language_settings.preferred_radix));
@@ -128,6 +131,11 @@ impl ApplicationState {
       modeline.push_str("Inf");
     } else {
       modeline.push_str("-  ");
+    }
+    if self.display_settings().language_settings.prefers_unicode_output {
+      modeline.push_str("U");
+    } else {
+      modeline.push_str("-");
     }
     if self.display_settings().is_graphics_enabled {
       modeline.push_str("Gr");

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -14,11 +14,29 @@ use either::Either;
 use num::One;
 use num::pow::Pow;
 
-use std::fmt::{self, Formatter, Display};
+use std::fmt::{self, Formatter, Debug, Display};
 use std::convert::Infallible;
 use std::cmp::{Reverse, Ordering};
 use std::iter::{self, Extend};
 use std::ops::{Mul, Neg};
+
+/// A singleton object whose output under the [`Debug`] trait is
+/// `"..."`. Used in debug output of some objects.
+///
+/// Example usage:
+///
+/// ```
+/// impl<T> Debug for SomeType<T> {
+///   fn fmt(&self, f: &mut Formatter) -> Result {
+///     f.debug_struct("SomeType")
+///       .field("name", &self.name)
+///       .field("value", &Ellipsis) // self.value of type T might not be Debug!
+///       .finish();
+///   }
+/// }
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Ellipsis;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Sign {
@@ -99,6 +117,18 @@ impl Display for Sign {
       Self::Negative => write!(f, "-"),
       Self::Positive => write!(f, "+"),
     }
+  }
+}
+
+impl Debug for Ellipsis {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    write!(f, "...")
+  }
+}
+
+impl Display for Ellipsis {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    write!(f, "...")
   }
 }
 

--- a/src/button_grid/display_button_grid.ts
+++ b/src/button_grid/display_button_grid.ts
@@ -36,6 +36,7 @@ export class DisplayButtonGrid extends ButtonGrid {
       [],
       [
         new DispatchButton(imageSvg(), "toggle_graphics", "G"),
+        new DispatchButton("¶", "toggle_unicode", "u"),
       ],
       [
         backButton(this.rootGrid),

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,10 @@ function refreshUndoButtons(uiManager: UiManager, state: UndoAvailabilityPayload
 
 function refreshModeline(payload: ModelinePayload) {
   const modeline = Page.getModelineBar();
-  modeline.innerHTML = payload.modelineText;
+  const pre = document.createElement("pre");
+  pre.innerHTML = payload.modelineText;
+  modeline.innerHTML = "";
+  modeline.appendChild(pre);
 }
 
 window.addEventListener("DOMContentLoaded", async function() {


### PR DESCRIPTION
This MR closes issue #111.

Unicode aliases are implemented. On output, a function, operator, or variable with a Unicode alias will be displayed via the alias. There is a user-level flag which can be flipped to disable this behavior, though the Unicode aliasing is enabled by default. On input, the relevant Unicode names are supported, and an expression simplifier runs very early in the simplification process to normalize them to the canonical ASCII names.

Currently, we have the following aliases:
* `∞` for `inf`.
* `⧝` for `uinf` (in theory, I wanted "infinity with a tilde over it", to match Wolfram, but that doesn't seem to exist as a Unicode character).
* `≤`, `≥`, and `≠` for, respectively, `<=`, `>=`, and `!=`.

There are no non-operator functions that have Unicode aliases at this time.